### PR TITLE
Add Docker build secrets for Git tokens and simplify addon fetch script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -137,6 +137,10 @@ KWKHTMLTOPDF_IMAGE=ghcr.io/acsone/kwkhtmltopdf:0.12.6.1-latest
 KWKHTMLTOPDF_PLATFORM=linux/amd64
 # Git tag/commit used to install the upstream drop-in client into the Odoo image.
 KWKHTMLTOPDF_CLIENT_REF=1.0
+# Build-time tokens are consumed from host environment via Docker secrets.
+# Define GITHUB_TOKEN/GITLAB_TOKEN/GIT_TOKEN in the env file used by Compose (or export them in shell).
+# For private Enterprise clones, ODOO_EE_GIT_HOST must match the repository URL host.
+# ODOO_ENTERPRISE_REPO may point to any Git host (not only GitHub).
 
 ###############################################
 # HTTP, proxy & realtime

--- a/.env.example
+++ b/.env.example
@@ -284,6 +284,10 @@ GITHUB_HOST=github.com
 GITLAB_HOST=gitlab.com
 GITHUB_USER=x-access-token
 GITLAB_USER=oauth2
+# Optional generic git token/host/user for non-GitHub/GitLab addon sources.
+GIT_TOKEN=
+GIT_HOST=
+GIT_USER=oauth2
 
 ###############################################
 # Enterprise edition options
@@ -291,5 +295,9 @@ GITLAB_USER=oauth2
 # Set ODOO_EDITION=ee to fetch Enterprise addons.
 ODOO_EE_ADDONS_DIR=/opt/enterprise-addons
 ODOO_ENTERPRISE_REPO=https://github.com/odoo/enterprise.git
+# Dedicated Enterprise auth variables used by build secret/args for odoo-core.
+ODOO_EE_GIT_TOKEN=
+ODOO_EE_GIT_HOST=github.com
+ODOO_EE_GIT_USER=x-access-token
 # Set to a commit SHA when you need reproducible Enterprise rebuilds.
 ODOO_ENTERPRISE_REF=

--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ Use another env file when needed:
 make up ENV_FILE=.env.staging COMPOSE_PROJECT_NAME=docker-odoo-staging
 ```
 
+## Build Secrets for Private Repositories
+
+Addon and Enterprise build steps read Git tokens from Docker build secrets backed by host environment variables.
+Before running `make build-base`, `make build-addons`, or `make init`, provide `GITHUB_TOKEN`, `GITLAB_TOKEN`, and/or `GIT_TOKEN` to Docker Compose.
+You can keep them in your selected env file (for example `.env` / `ENV_FILE=...`) — manual `export` is optional and only needed if you do not use an env file.
+
+`ODOO_ENTERPRISE_REPO` can target non-GitHub hosts, but `ODOO_EE_GIT_HOST` must match the repository URL host for private clone authentication.
+
 ## Local Use
 
 For local work, keep the production topology and use a local domain.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ You can keep them in your selected env file (for example `.env` / `ENV_FILE=...`
 
 `ODOO_ENTERPRISE_REPO` can target non-GitHub hosts, but `ODOO_EE_GIT_HOST` must match the repository URL host for private clone authentication.
 
+In `docker-compose.yml` secrets declared with `environment:` must use the variable name (for example `environment: GITHUB_TOKEN`), not `${GITHUB_TOKEN}`.
+
 ## Local Use
 
 For local work, keep the production topology and use a local domain.

--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ make up ENV_FILE=.env.staging COMPOSE_PROJECT_NAME=docker-odoo-staging
 ## Build Secrets for Private Repositories
 
 Addon and Enterprise build steps read Git tokens from Docker build secrets backed by host environment variables.
-Before running `make build-base`, `make build-addons`, or `make init`, provide `GITHUB_TOKEN`, `GITLAB_TOKEN`, and/or `GIT_TOKEN` to Docker Compose.
+Before running `make build-base`, `make build-addons`, or `make init`, provide Git tokens to Docker Compose (`ODOO_EE_GIT_TOKEN` for Enterprise build, plus `GITHUB_TOKEN`/`GITLAB_TOKEN`/`GIT_TOKEN` for extra addons as needed).
 You can keep them in your selected env file (for example `.env` / `ENV_FILE=...`) — manual `export` is optional and only needed if you do not use an env file.
 
-`ODOO_ENTERPRISE_REPO` can target non-GitHub hosts, but `ODOO_EE_GIT_HOST` must match the repository URL host for private clone authentication.
+`ODOO_ENTERPRISE_REPO` can target non-GitHub hosts; set matching `ODOO_EE_GIT_HOST`/`ODOO_EE_GIT_USER`/`ODOO_EE_GIT_TOKEN` for private Enterprise clone authentication.
 
 In `docker-compose.yml` secrets declared with `environment:` must use the variable name (for example `environment: GITHUB_TOKEN`), not `${GITHUB_TOKEN}`.
 

--- a/addons/Dockerfile
+++ b/addons/Dockerfile
@@ -23,9 +23,12 @@ COPY addons/requirements.txt /tmp/requirements.txt
 RUN pip3 install --no-cache-dir -r /tmp/requirements.txt && rm -f /tmp/requirements.txt
 
 # --- Install Extra Addons
-RUN --mount=type=secret,id=github_token,env=GITHUB_TOKEN \
-    --mount=type=secret,id=gitlab_token,env=GITLAB_TOKEN \
-    --mount=type=secret,id=git_token,env=GIT_TOKEN \
+RUN --mount=type=secret,id=github_token,target=/run/secrets/github_token,required=false \
+    --mount=type=secret,id=gitlab_token,target=/run/secrets/gitlab_token,required=false \
+    --mount=type=secret,id=git_token,target=/run/secrets/git_token,required=false \
+    GITHUB_TOKEN="$(cat /run/secrets/github_token 2>/dev/null || true)" \
+    GITLAB_TOKEN="$(cat /run/secrets/gitlab_token 2>/dev/null || true)" \
+    GIT_TOKEN="$(cat /run/secrets/git_token 2>/dev/null || true)" \
     mkdir -p ${EXTRA_ADDONS_DIR} && chown odoo ${EXTRA_ADDONS_DIR} \
     && /extra-addons.sh \
         --addons-file=/usr/local/share/odoo/manifests/addons.yml \

--- a/addons/Dockerfile
+++ b/addons/Dockerfile
@@ -6,6 +6,13 @@ ARG BASE_IMAGE=odoo-core-${ODOO_EDITION}:${ODOO_VERSION}
 FROM ${BASE_IMAGE}
 
 ARG ADDONS_YML=addons/addons.yml
+ARG GIT_HOST
+ARG GIT_USER
+ARG GITHUB_HOST
+ARG GITLAB_HOST
+ARG GITHUB_USER
+ARG GITLAB_USER
+
 COPY ${ADDONS_YML} /usr/local/share/odoo/manifests/addons.yml
 
 USER root
@@ -16,11 +23,13 @@ COPY addons/requirements.txt /tmp/requirements.txt
 RUN pip3 install --no-cache-dir -r /tmp/requirements.txt && rm -f /tmp/requirements.txt
 
 # --- Install Extra Addons
-RUN mkdir -p ${EXTRA_ADDONS_DIR} && chown odoo ${EXTRA_ADDONS_DIR} \
+RUN --mount=type=secret,id=github_token,env=GITHUB_TOKEN \
+    --mount=type=secret,id=gitlab_token,env=GITLAB_TOKEN \
+    --mount=type=secret,id=git_token,env=GIT_TOKEN \
+    mkdir -p ${EXTRA_ADDONS_DIR} && chown odoo ${EXTRA_ADDONS_DIR} \
     && /extra-addons.sh \
         --addons-file=/usr/local/share/odoo/manifests/addons.yml \
-        --addons-dir=${EXTRA_ADDONS_DIR} \
-        --env-file=${ODOO_ENV_FILE}
+        --addons-dir=${EXTRA_ADDONS_DIR}
 
 # Set default user when running the container
 USER odoo

--- a/addons/Dockerfile
+++ b/addons/Dockerfile
@@ -23,16 +23,26 @@ COPY addons/requirements.txt /tmp/requirements.txt
 RUN pip3 install --no-cache-dir -r /tmp/requirements.txt && rm -f /tmp/requirements.txt
 
 # --- Install Extra Addons
-RUN --mount=type=secret,id=github_token,target=/run/secrets/github_token,required=false \
-    --mount=type=secret,id=gitlab_token,target=/run/secrets/gitlab_token,required=false \
-    --mount=type=secret,id=git_token,target=/run/secrets/git_token,required=false \
-    GITHUB_TOKEN="$(cat /run/secrets/github_token 2>/dev/null || true)" \
-    GITLAB_TOKEN="$(cat /run/secrets/gitlab_token 2>/dev/null || true)" \
-    GIT_TOKEN="$(cat /run/secrets/git_token 2>/dev/null || true)" \
-    mkdir -p ${EXTRA_ADDONS_DIR} && chown odoo ${EXTRA_ADDONS_DIR} \
+RUN --mount=type=secret,id=github_token,required=false \
+    --mount=type=secret,id=gitlab_token,required=false \
+    --mount=type=secret,id=git_token,required=false \
+    GITHUB_TOKEN="$(cat /run/secrets/github_token 2>/dev/null || true)"; \
+    GITLAB_TOKEN="$(cat /run/secrets/gitlab_token 2>/dev/null || true)"; \
+    GIT_TOKEN="$(cat /run/secrets/git_token 2>/dev/null || true)"; \
+    mkdir -p "${EXTRA_ADDONS_DIR}" \
+    && chown odoo:odoo "${EXTRA_ADDONS_DIR}" \
     && /extra-addons.sh \
         --addons-file=/usr/local/share/odoo/manifests/addons.yml \
-        --addons-dir=${EXTRA_ADDONS_DIR}
+        --addons-dir="${EXTRA_ADDONS_DIR}" \
+        --github-user="${GITHUB_USER}" \
+        --github-token="${GITHUB_TOKEN}" \
+        --github-host="${GITHUB_HOST}" \
+        --gitlab-user="${GITLAB_USER}" \
+        --gitlab-token="${GITLAB_TOKEN}" \
+        --gitlab-host="${GITLAB_HOST}" \
+        --git-user="${GIT_USER}" \
+        --git-token="${GIT_TOKEN}" \
+        --git-host="${GIT_HOST}"
 
 # Set default user when running the container
 USER odoo

--- a/base/scripts/extra-addons.sh
+++ b/base/scripts/extra-addons.sh
@@ -18,88 +18,6 @@ set -euo pipefail
 
 ADDONS_FILE=""
 
-load_env_file() {
-  local env_file="$1"
-
-  if [[ ! -r "${env_file}" ]]; then
-    if [[ -e "${env_file}" ]]; then
-      echo "WARNING: --env-file provided but not readable: ${env_file}" >&2
-    else
-      echo "INFO: --env-file provided but not found: ${env_file} (continuing without it)" >&2
-    fi
-    return 0
-  fi
-
-  echo "INFO: Loading environment variables from ${env_file}" >&2
-  while IFS='=' read -r key value; do
-    case "${key}" in
-      GITHUB_HOST|GITLAB_HOST|GIT_HOST|GITHUB_USER|GITLAB_USER|GIT_USER|GITHUB_TOKEN|GITLAB_TOKEN|GIT_TOKEN)
-        printf -v "${key}" '%s' "${value}"
-        export "${key?}"
-        ;;
-    esac
-  done < <(python3 - "${env_file}" <<'PY'
-import re
-import sys
-
-path = sys.argv[1]
-key_re = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-
-
-def store(key, value):
-    if key_re.match(key):
-        print(f"{key}={value}")
-
-
-with open(path, encoding="utf-8") as fh:
-    for raw in fh:
-        line = raw.strip()
-        if not line or line.startswith("#"):
-            continue
-        if line.startswith("export "):
-            line = line[7:].lstrip()
-        if "=" not in line:
-            continue
-
-        key, value = line.split("=", 1)
-        key = key.strip()
-        value = value.rstrip("\r")
-
-        if value.startswith('"') and value.endswith('"') and len(value) >= 2:
-            try:
-                value = bytes(value[1:-1], "utf-8").decode("unicode_escape")
-            except Exception:
-                value = value[1:-1]
-        elif value.startswith("'") and value.endswith("'") and len(value) >= 2:
-            value = value[1:-1]
-        else:
-            value = re.split(r"\s+#", value, 1)[0].strip()
-
-        store(key, value)
-PY
-  )
-}
-
-# -------------------- Pre-scan only --env-file ----
-ARGS=("$@")
-for ((i=0; i<${#ARGS[@]}; i++)); do
-  case "${ARGS[i]}" in
-    --env-file=*)
-      ENV_FILE="${ARGS[i]#*=}"
-      ;;
-    --env-file)
-      if (( i+1 < ${#ARGS[@]} )); then ENV_FILE="${ARGS[i+1]}"; fi
-      ;;
-  esac
-done
-
-# -------------------- Load selected .env variables --------------------
-if [[ -n "${ENV_FILE:-}" ]]; then
-  load_env_file "${ENV_FILE}"
-else
-  echo "INFO: No --env-file provided; relying on environment variables." >&2
-fi
-
 # -------------------- Args --------------------
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -107,9 +25,6 @@ while [[ $# -gt 0 ]]; do
     --addons-file=*)     ADDONS_FILE="${1#*=}"; shift ;;
     --addons-dir)        ADDONS_DIR="${2:-}"; shift 2 ;;
     --addons-dir=*)      ADDONS_DIR="${1#*=}"; shift ;;
-    --env-file)          ENV_FILE="${2:-}"; shift 2 ;;
-    --env-file=*)        ENV_FILE="${1#*=}"; shift ;;
-
     --github-user)       GITHUB_USER="${2:-}"; shift 2 ;;
     --github-user=*)     GITHUB_USER="${1#*=}"; shift ;;
     --github-token)      GITHUB_TOKEN="${2:-}"; shift 2 ;;
@@ -213,11 +128,7 @@ fi
 # -------------------- Aggregate --------------------
 (
   cd "$TMP_ADDONS_DIR"
-  if [[ -n "${ENV_FILE:-}" && -r "${ENV_FILE}" ]]; then
-    gitaggregate -c "$ADDONS_YML" --expand-env --env-file "${ENV_FILE}"
-  else
-    gitaggregate -c "$ADDONS_YML" --expand-env
-  fi
+  gitaggregate -c "$ADDONS_YML" --expand-env
 )
 
 # -------------------- Copy real addons --------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,19 @@ services:
       dockerfile: addons/Dockerfile
       args:
         BASE_IMAGE: odoo-core-${ODOO_EDITION:-ce}:${ODOO_VERSION:-18.0}
+        GIT_HOST: ${GIT_HOST:-}
+        GIT_USER: ${GIT_USER:-oauth2}
+        GITHUB_HOST: ${GITHUB_HOST:-github.com}
+        GITLAB_HOST: ${GITLAB_HOST:-gitlab.com}
+        GITHUB_USER: ${GITHUB_USER:-x-access-token}
+        GITLAB_USER: ${GITLAB_USER:-oauth2}
+      secrets:
+        - source: github_token
+          target: github_token
+        - source: gitlab_token
+          target: gitlab_token
+        - source: git_token
+          target: git_token
     environment:
       ODOO_ENV_FILE: "/run/odoo/.env"
       DB_HOST: ${DB_HOST}
@@ -180,3 +193,9 @@ networks:
 secrets:
   odoo_ee_git_token:
     environment: GITHUB_TOKEN
+  github_token:
+    environment: GITHUB_TOKEN
+  gitlab_token:
+    environment: GITLAB_TOKEN
+  git_token:
+    environment: GIT_TOKEN

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,7 +80,7 @@ services:
       - "8069"
       - "8072"
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:8069/web/login >/dev/null"]
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:8069/web/health >/dev/null"]
       interval: 15s
       timeout: 5s
       retries: 12

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,14 +10,9 @@ services:
       args:
         ODOO_EDITION: ${ODOO_EDITION:-ce} # ce (Odoo Community Edition) or ee (Odoo Enterprise Edition)
 
-        # For Enterprise private repository authentication (default values are for Github)
-        ODOO_EE_GIT_USER: ${GITHUB_USER:-x-access-token}
-        ODOO_EE_GIT_HOST: ${GITHUB_HOST:-github.com}
-
-        # If you want to use your own git host for ee addons, you can change the values in .env file
-        # ODOO_EE_GIT_USER: ${GIT_USER:-x-access-token} # Git host personal access token user
-        # ODOO_EE_GIT_TOKEN: ${GIT_TOKEN:-} # Git host personal access token token
-        # ODOO_EE_GIT_HOST: ${GIT_HOST:-github.com} # Git host (e.g. github.com, gitlab.com, etc.)
+        # For Enterprise private repository authentication
+        ODOO_EE_GIT_USER: ${ODOO_EE_GIT_USER:-${GITHUB_USER:-x-access-token}}
+        ODOO_EE_GIT_HOST: ${ODOO_EE_GIT_HOST:-${GITHUB_HOST:-github.com}}
 
         # Optional Arguments (you can change default values if needed just uncomment and change the values in .env file)
         ODOO_CE_VERSION: ${ODOO_CE_VERSION:-${ODOO_VERSION:-18.0}} # CE series/tag used as a fallback
@@ -192,7 +187,7 @@ networks:
 
 secrets:
   odoo_ee_git_token:
-    environment: GITHUB_TOKEN
+    environment: ODOO_EE_GIT_TOKEN
   github_token:
     environment: GITHUB_TOKEN
   gitlab_token:


### PR DESCRIPTION
### Motivation
- Allow private addon/enterprise repository clones during image builds by consuming host Git tokens via Docker build secrets. 
- Simplify the addon aggregation flow by removing fragile `.env` pre-scan and loader logic from the `extra-addons.sh` script. 
- Document the new build-secret workflow so users know to provide `GITHUB_TOKEN`, `GITLAB_TOKEN`, or `GIT_TOKEN`. 

### Description
- Add explanatory comments to `.env.example` and a new "Build Secrets for Private Repositories" section in `README.md` describing how to provide `GITHUB_TOKEN`, `GITLAB_TOKEN`, and `GIT_TOKEN`. 
- Update `addons/Dockerfile` to declare additional `ARG`s for Git host/user values and to mount Docker build secrets using `--mount=type=secret,id=...` for `github_token`, `gitlab_token`, and `git_token`, and remove passing `--env-file` into the addon installer. 
- Simplify `base/scripts/extra-addons.sh` by removing the `.env` file loader, the pre-scan for `--env-file`, and the `--env-file` CLI option, and always run `gitaggregate -c ... --expand-env` without conditional env-file handling. 
- Expose the new secrets and build args in `docker-compose.yml` (add `GIT_*`/`GITHUB_*`/`GITLAB_*` build `args`, add `secrets` to the `odoo` build, and declare `github_token`, `gitlab_token`, and `git_token` under the `secrets` section). 

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f9aa97dc448329a220f53ade0ad7c6)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Docker build-time authentication and addon fetching flow, which could break image builds for private/public addon sources if secrets/args are misconfigured. Runtime behavior is largely unchanged aside from how addons are baked into the image.
> 
> **Overview**
> Builds can now pull **private Enterprise and addon repositories** by passing Git tokens via **Docker BuildKit secrets** instead of reading tokens from an `--env-file` during the image build.
> 
> This updates the addons image build to mount `github_token`/`gitlab_token`/`git_token` secrets and pass Git host/user values as build args, and it simplifies `extra-addons.sh` by removing the `.env` loader/`--env-file` option and always running `gitaggregate ... --expand-env`. Docs and `.env.example` are updated to describe the new token variables and dedicated `ODOO_EE_GIT_*` settings, and `docker-compose.yml` now declares the new secrets and wires them into the `odoo` build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b36387b3c2f84b838e84239d65db843c7570b48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->